### PR TITLE
pat: fix typo in tuple_default!

### DIFF
--- a/text/pat/README.md
+++ b/text/pat/README.md
@@ -56,7 +56,7 @@ macro_rules! tuple_default {
         (
             $(
                 replace_expr!(
-                    ($tup_ty)
+                    ($tup_tys)
                     Default::default()
                 ),
             )*


### PR DESCRIPTION
There was a typo in the macro. But the larger question remains: to pluralize or not to pluralize the names of repeated captures?
