### PR TITLE
Correct statments typo

### DIFF
--- a/text/mbe-macro-rules.md
+++ b/text/mbe-macro-rules.md
@@ -58,7 +58,7 @@ Patterns can also contain captures.  These allow input to be matched based on so
 Captures are written as a dollar (`$`) followed by an identifier, a colon (`:`), and finally the kind of capture, which must be one of the following:
 
 * `item`: an item, like a function, struct, module, etc.
-* `block`: a block (i.e. a block of statments and/or an expression, surrounded by braces)
+* `block`: a block (i.e. a block of statements and/or an expression, surrounded by braces)
 * `stmt`: a statement
 * `pat`: a pattern
 * `expr`: an expression


### PR DESCRIPTION
In `mbe-macro-rules.md` file statements was misspelled as statments.
This commit fixes this small mistake.
