### PR TITLE
Typo: textural -> textual

### DIFF
--- a/text/mbe-syn-expansion.md
+++ b/text/mbe-syn-expansion.md
@@ -16,7 +16,7 @@ In fact, it can turn a syntax extension result into any of the following:
 
 In other words, *where* you can invoke a macro determines what its result will be interpreted as.
 
-The compiler will take this AST node and completely replace the macro's invocation node with the output node.  *This is a structural operation*, not a textural one!
+The compiler will take this AST node and completely replace the macro's invocation node with the output node.  *This is a structural operation*, not a textual one!
 
 For example, consider the following:
 


### PR DESCRIPTION
I assume that Rust macros are being contrasted with C-style text-based macros, rather than with, say, a fuzzy tennis ball or a gritty cat tongue.