### PR TITLE
Update macro rules to account for 1.32.0 changes

### DIFF
--- a/text/mbe-macro-rules.md
+++ b/text/mbe-macro-rules.md
@@ -67,6 +67,7 @@ Captures are written as a dollar (`$`) followed by an identifier, a colon (`:`),
 * `path`: a path (e.g. `foo`, `::std::mem::replace`, `transmute::<_, int>`, …)
 * `meta`: a meta item; the things that go inside `#[...]` and `#![...]` attributes
 * `tt`: a single token tree
+* `literal`: a literal (e.g. "string", 'c', 1)
 
 For example, here is a macro which captures its input as an expression:
 
@@ -105,7 +106,7 @@ Patterns can contain repetitions.  These allow a sequence of tokens to be matche
 * `$` is a literal dollar token.
 * `( ... )` is the paren-grouped pattern being repeated.
 * `sep` is an *optional* separator token.  Common examples are `,`, and `;`.
-* `rep` is the *required* repeat control.  Currently, this can be *either* `*` (indicating zero or more repeats) or `+` (indicating one or more repeats).  You cannot write "zero or one" or any other more specific counts or ranges.
+* `rep` is the *required* repeat control.  Currently, this can be *either* `*` (indicating zero or more repeats), `+` (indicating one or more repeats), or `?` (indicating zero or one repeats).  You cannot write "one or two" or any other more specific counts or ranges.
 
 Repetitions can contain any other valid pattern, including literal token trees, captures, and other repetitions.
 


### PR DESCRIPTION
https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html

Macro improvements
A few improvements to macros have landed in Rust 1.32.0. First, a new `literal` matcher was added:

```rust
macro_rules! m {
    ($lt:literal) => {};
}

fn main() {
    m!("some string literal");
}
```
`literal` matches against literals of any type; string literals, numeric literals, `char` literals.

In the 2018 edition, `macro_rules` macros can also use `?`, like this:

```rust
macro_rules! bar {
    ($(a)?) => {}
}
```
The `?` will match zero or one repetitions of the pattern, similar to the already-existing `*` for "zero or more" and `+` for "one or more."