### PR TITLE
Added Markdownlint configuration

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,6 @@
     "first-line-heading": false,
     "no-trailing-spaces": false,
     "ul-indent": { "indent": 4 },
-    "line-length": false
+    "line-length": false,
+    "no-inline-html": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "first-line-heading": false,
+    "no-trailing-spaces": false,
+    "ul-indent": { "indent": 4 },
+    "line-length": false
+}


### PR DESCRIPTION
Hello @DanielKeep and others.

I was looking over the repository and my editor complained about the Markdown. I am using [Markdownlint](https://github.com/DavidAnson/markdownlint) to check my Markdown as I write it. To avoid issues, I added a **Markdownlint** configuration and decided to share it with you.

If you have questions to the configuration or Markdownlint in generation I will gladly answer these. If you would like to get Markdownlint integrated with CI using Travis or similar please let me know.

The initial revision disables or configures **Markdownlint** rules to make the current source pass the **Markdownlint** check.

The following rules, should be addressed:

- `no-trailing-spaces`, should be easy, have a look at [EditorConfig](https://editorconfig.org/) or similar

The following rules can just be kept in the specified configuration.

- `first-line-heading`, seems to conflict with the implementation, which uses `%` for indicating headings. (This is not-markdown) and is expected to be something local

- `ul-indent`, has been configured from the default of `2` to `4`. This is primarily addressing issues in Summary.md

- `line-length` rule, has been configured to `false`indicating disabled, since length of lines is a _style_ issue. Could be addressed with EditorConfig or similar

Ref: https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md