### PR TITLE
remove contradictory sentence about macros requiring valid Rust syntax as input

### DIFF
--- a/text/mbe-syn-macros-in-the-ast.md
+++ b/text/mbe-syn-macros-in-the-ast.md
@@ -1,6 +1,6 @@
 % Macros in the AST
 
-As previously mentioned, macro processing in Rust happens *after* the construction of the AST.  As such, the syntax used to invoke a macro *must* be a proper part of the language's syntax.  In fact, there are several "syntax extension" forms which are part of Rust's syntax.  Specifically, the following forms (by way of examples):
+As previously mentioned, macro processing in Rust happens *after* the construction of the AST.  In fact, there are several "syntax extension" forms which are part of Rust's syntax.  Specifically, the following forms (by way of examples):
 
 * `# [ $arg ]`; *e.g.* `#[derive(Clone)]`, `#[no_mangle]`, …
 * `# ! [ $arg ]`; *e.g.* `#![allow(dead_code)]`, `#![crate_name="blang"]`, …


### PR DESCRIPTION
#19 discusses various outdated parts of the `Macros in the AST` chapter. This PR removes the part about macro input having to be valid Rust syntax. 

@bjorn3 , I think that your remark in https://github.com/DanielKeep/tlborm/issues/19#issuecomment-703573810 is already covered below in the chapter when it says
> the argument of a syntax extension invocation is a single token tree