### PR TITLE
Remove disclaimer and note

### DIFF
--- a/text/blk-ast-coercion.md
+++ b/text/blk-ast-coercion.md
@@ -14,7 +14,7 @@ macro_rules! as_ty   { ($t: ty)  => {$t} }
 # as_item!{struct Dummy;}
 # 
 # fn main() {
-#     as_stmt!(let as_pat!(_): as_ty(usize) = as_expr!(42));
+#     as_stmt!(let as_pat!(_): as_ty!(usize) = as_expr!(42));
 
 # }
 ```

--- a/text/blk-ast-coercion.md
+++ b/text/blk-ast-coercion.md
@@ -7,20 +7,18 @@ The Rust parser is not very robust in the face of `tt` substitutions.  Problems 
 # 
 macro_rules! as_expr { ($e:expr) => {$e} }
 macro_rules! as_item { ($i:item) => {$i} }
-macro_rules! as_pat  { ($p:pat) =>  {$p} }
+macro_rules! as_pat  { ($p:pat)  => {$p} }
 macro_rules! as_stmt { ($s:stmt) => {$s} }
+macro_rules! as_ty   { ($t: ty)  => {$t} }
 # 
 # as_item!{struct Dummy;}
 # 
 # fn main() {
-#     as_stmt!(let as_pat!(_) = as_expr!(42));
+#     as_stmt!(let as_pat!(_): as_ty(usize) = as_expr!(42));
+
 # }
 ```
 
 These coercions are often used with [push-down accumulation] macros in order to get the parser to treat the final `tt` sequence as a particular kind of grammar construct.
 
-Note that this specific set of macros is determined by what macros are allowed to expand to, *not* what they are able to capture.  That is, because macros cannot appear in type position[^issue-27245], you cannot have an `as_ty!` macro.
-
 [push-down accumulation]: pat-push-down-accumulation.html
-
-[^issue-27245]: See [Issue #27245](https://github.com/rust-lang/rust/issues/27245).


### PR DESCRIPTION
[#27245](https://github.com/rust-lang/rust/issues/27245) Has been completed since 2015. This pull removes the disclaimer that a `as_ty!()` macro wouldn't work.